### PR TITLE
balena-image-initramfs: re-add the kexec pi4 fwgpio module

### DIFF
--- a/recipes-core/images/balena-image-initramfs.bbappend
+++ b/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,2 +1,3 @@
+PACKAGE_INSTALL:append = " initramfs-module-kexec-pi4-fwgpio"
 IMAGE_ROOTFS_MAXSIZE = "65536"
 IMAGE_ROOTFS_MAXSIZE:raspberrypi4-64 = "65536"


### PR DESCRIPTION
This was mistakenly drop in the transition of functionality to this branch.

Change-type: patch