### PR TITLE
classes/sb-override: Add :sb override, drop redundant size globals

### DIFF
--- a/classes/sb-override.bbclass
+++ b/classes/sb-override.bbclass
@@ -1,0 +1,7 @@
+# Adds ":sb" to OVERRIDES, so other layers can use VAR:machine:sb
+# overrides that only apply when this layer is inherited.
+python () {
+    overrides = d.getVar('MACHINEOVERRIDES') or ''
+    if 'sb' not in overrides.split(':'):
+        d.setVar('MACHINEOVERRIDES', overrides + ':sb')
+}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,3 +10,6 @@ BBFILE_PRIORITY_balena-rpi-sb = "1337"
 LAYERSERIES_COMPAT_balena-rpi-sb = "kirkstone"
 
 BALENA_NONENC_BOOT_LABEL = "balena-rpi"
+
+# Lets other layers detect this layer via the "sb" override.
+INHERIT += "sb-override"

--- a/recipes-core/images/balena-image-sb.inc
+++ b/recipes-core/images/balena-image-sb.inc
@@ -1,6 +1,3 @@
-# Increase boot partition size
-BALENA_BOOT_SIZE = "174080"
-
 BALENA_ESSENTIAL_BOOT_FILES:append:raspberrypi4-64 = " \
     cmdline.txt  \
     config.txt  \
@@ -30,7 +27,5 @@ IMAGE_INSTALL:append = " grub-editenv"
 
 do_rootfs[depends] += " virtual/balena-bootloader:do_deploy"
 do_image_balenaos_img[depends] += " virtual/balena-bootloader:do_deploy"
-
-IMAGE_ROOTFS_SIZE ="655360"
 
 inherit image-sign-rpi


### PR DESCRIPTION
## Summary
- Adds a ':sb' MACHINEOVERRIDES override, applied via a bbclass inherited from layer.conf, so other layers can use `VAR:machine:sb` overrides that only apply when this layer is present.
- Removes the now-redundant bare `BALENA_BOOT_SIZE`/`IMAGE_ROOTFS_SIZE` globals from balena-image-sb.inc, since the calling layer now sets them via a `machine:sb` override instead.